### PR TITLE
Update EditEvent.jsx

### DIFF
--- a/src/pages/Events/EditEvent.jsx
+++ b/src/pages/Events/EditEvent.jsx
@@ -25,8 +25,8 @@ const EditEvent = () => {
     const [newEventLink, setNewEventLink] = useState(event.link || "");
     const [newEventImage, setNewEventImage] = useState(null);
     const [newEventOverview, setNewEventOverview] = useState(event.overview || "");
-    const [newEventStatus, setNewEventStatus] = useState(event.status || true);
-    const [newEventType, setNewEventType] = useState(event.teamEvent || true);
+    const [newEventStatus, setNewEventStatus] = useState(event.status ?? true);
+    const [newEventType, setNewEventType] = useState(event.teamEvent ?? true);
     const [newEventTimeline, setNewEventTimeline] = useState(event.timeline || "");
     const [newContacts, setNewContacts] = useState(event.contacts || []);
 


### PR DESCRIPTION
Fixed the bug:
When clicked on edit event, it changes the Event status and type to active and team again even if it was set to unactive and individual at the time of creation.